### PR TITLE
ci: align tests.yml with cask-tap needs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,41 +1,39 @@
 name: brew test-bot
+
 on:
   push:
     branches:
       - main
   pull_request:
+
 jobs:
   test-bot:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Homebrew Bundler RubyGems
-        id: cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
 
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax
-
-      - name: Upload bottles as artifact
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: bottles
-          path: '*.bottle.*'


### PR DESCRIPTION
## Summary
Adopts current \`brew tap-new\` scaffold conventions and drops formula-tap residue that doesn't apply to a casks-only tap.

**Scaffold-style improvements:**
- \`fail-fast: false\` — one OS failing no longer cancels the others
- Cache key keyed on \`matrix.os\` instead of \`runner.os\` (otherwise \`macos-14\`, \`macos-15\`, and \`macos-26\` all share one cache entry — last-writer wins)
- Least-privilege \`permissions:\` block
- Pass \`token\` to \`setup-homebrew@main\` (per current scaffold)
- Drop the manual \`brew install-bundler-gems\` step — \`setup-homebrew\` handles bundler installation now

**Cask-specific cleanup:**
- Drop the \`*.bottle.*\` artifact upload step. Casks describe pre-built apps and do not produce bottle files, so this glob has been matching nothing.

\`brew test-bot --only-tap-syntax\` is retained — it runs \`brew style\` / \`brew audit\` against the casks, which is the actual signal this workflow provides.

## Test plan
- [ ] CI green on Ubuntu + macOS 14/15/26
- [ ] No regression in style/audit signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)