### PR TITLE
ci: add daily bump-cask-pr check

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,34 @@
+name: Bump casks
+
+on:
+  schedule:
+    # Daily at 08:00 UTC. brew bump is a no-op when nothing is outdated.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      casks:
+        description: "Casks to check/bump (space-separated, blank = all)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    if: github.repository_owner == 'educelab'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git user
+        uses: Homebrew/actions/git-user-config@main
+
+      - name: Bump packages
+        uses: Homebrew/actions/bump-packages@main
+        with:
+          token: ${{ secrets.BUMP_PR_PAT }}
+          fork: false
+          casks: ${{ inputs.casks || 'landmarks-picker volume-cartographer' }}


### PR DESCRIPTION
## Summary
Adds a daily \`brew bump --casks\` job that opens a PR whenever upstream has cut a new release. No-op when nothing is outdated.

- **Schedule:** daily at 08:00 UTC
- **Manual run:** \`workflow_dispatch\` with optional space-separated cask list (blank = all)
- **Scope:** \`landmarks-picker volume-cartographer\` (hard-coded so new casks must be explicitly opted in — keeps bump behavior predictable as the tap grows)
- **Permissions:** read-only at the workflow level; the bump action authenticates with a PAT

## Setup required before this is useful
A \`BUMP_PR_PAT\` repository secret (PAT with \`repo\` scope on this repo) must be configured. The default \`GITHUB_TOKEN\` is intentionally not used — PRs it opens won't trigger downstream workflows like \`tests.yml\`, which defeats the purpose of an auto-bumped PR.

## Known caveats
\`brew bump --casks\` discovers new versions via \`livecheck\` blocks or recognizable URL patterns:

- **volume-cartographer** uses a GitHub releases URL → should bump cleanly without further work.
- **landmarks-picker** uses a GitLab generic-package URL → likely needs a \`livecheck\` block added before it bumps cleanly. Failures surface in the workflow log; adding livecheck can be a follow-up.

## Test plan
- [ ] Workflow runs to completion on the schedule or manual dispatch
- [ ] Opens a PR when a new upstream release exists; no-op otherwise
- [ ] Bumper PR triggers \`tests.yml\` (confirms PAT setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)